### PR TITLE
Bump versions for 3.2.0 release. (#55)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,11 +28,11 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 
 name := "chisel-module-template"
 
-version := "3.1.1"
+version := "3.2.0"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+crossScalaVersions := Seq("2.12.10", "2.11.12")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
@@ -41,8 +41,8 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "[1.2.5,1.3-SNAPSHOT["
+  "chisel3" -> "3.2.+",
+  "chisel-iotesters" -> "1.3.+"
   )
 
 libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.3.2


### PR DESCRIPTION
* Bump versions for 3.2.0 release.

* Switch to Scala 2.12 as the "default".